### PR TITLE
Load images async

### DIFF
--- a/VattenMedia/VattenMedia.csproj
+++ b/VattenMedia/VattenMedia.csproj
@@ -12,6 +12,7 @@
     <AssemblyVersion>5.1.0.0</AssemblyVersion>
     <Version>5.1.0</Version>
     <ApplicationIcon>vattenmedia8.ico</ApplicationIcon>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VattenMedia/ViewModels/MainWindowViewModel.cs
+++ b/VattenMedia/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Timers;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -182,7 +183,13 @@ namespace VattenMedia.ViewModels
                     .OrderByDescending(x => configHandler.IsFavorited(x.Name))
                     .ThenByDescending(x => x.Viewers))
                 {
-                    LiveChannels.Add(new LiveChannel(channel, configHandler.IsFavorited(channel.Name)));
+                    var liveChannel = new LiveChannel(channel, configHandler.IsFavorited(channel.Name));
+                    LiveChannels.Add(liveChannel);
+                    _ = Task.Run(() =>
+                    {
+                        liveChannel.LoadImage();
+                        liveChannel.OnPropertyChanged(nameof(liveChannel.Image));
+                    });
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Images are slower to download with the new API - this PR makes them load async, making the functionality available before images are downloaded.